### PR TITLE
Make proxies more resilient against dropping app servers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import { initializeRoutes } from './routes';
 import { initializeServerList } from './serverManager';
 import { initializeProxyServerList } from './proxyManager';
 import { logicalTimestampMiddleware } from './logicalTimestampMiddleware';
+import { initialProxyList, initialServerList } from './initialValues';
 
 const PORT = 3005;
 
@@ -26,15 +27,10 @@ console.log("Initializing routes...");
 initializeRoutes(app);
 
 console.log("Initializing proxies...");
-const proxyOne = 'https://559proxy.vercel.app';
-const proxyTwo = 'https://559proxy-2.vercel.app';
-initializeProxyServerList([proxyOne, proxyTwo]);
+initializeProxyServerList(initialProxyList);
 
 console.log("Initializing servers...");
-const serverOne = 'https://appserver559-3.herokuapp.com';
-const serverTwo = `https://appserver559-2.herokuapp.com`;
-const serverThree = `https://appserver559-1.herokuapp.com`
-initializeServerList([serverOne, serverTwo, serverThree]);
+initializeServerList(initialServerList);
 
 app.listen(PORT);
 console.log(`==== App listening on port ${PORT} ====`);

--- a/src/handleRejections.ts
+++ b/src/handleRejections.ts
@@ -1,0 +1,27 @@
+import axios from "axios";
+import { resyncBadServers } from "./resyncBadServers";
+import { removeServer } from "./serverManager";
+
+async function recoverFromAllRejected(serverUrls: string[]){
+    console.log('Recovering from all servers being rejected');
+    const promises = serverUrls.map(url => axios.get(`${url}/ping`));
+    const fulfilled = await Promise.allSettled(promises);
+    fulfilled.forEach((res, i) => {
+        if(res.status === `rejected`){
+            removeServer(serverUrls[i]);
+        } else {
+            console.log(`Server ${serverUrls[i]} was actually fine`);
+        }
+    });
+}
+
+export async function handleRejections(allServers: string[], badServers: string[]){
+    console.log("Handling rejections");
+    if(badServers.length === 0) return;
+    const goodServers = allServers.filter(url => !badServers.includes(url));
+    if(goodServers.length !== 0){
+        resyncBadServers(goodServers, badServers);
+        return;
+    }
+    recoverFromAllRejected(badServers);
+}

--- a/src/initialValues.ts
+++ b/src/initialValues.ts
@@ -1,0 +1,8 @@
+const serverOne = 'https://appserver559-3.herokuapp.com';
+const serverTwo = `https://appserver559-2.herokuapp.com`;
+const serverThree = `https://appserver559-1.herokuapp.com`
+export const initialServerList = [serverOne, serverTwo, serverThree];
+
+const proxyOne = 'https://559proxy.vercel.app';
+const proxyTwo = 'https://559proxy-2.vercel.app';
+export const initialProxyList = [proxyOne, proxyTwo];

--- a/src/proxyManager.ts
+++ b/src/proxyManager.ts
@@ -3,6 +3,9 @@ import { THIS_URL } from "./env";
 const ACTIVE_PROXIES = [];
 
 export function initializeProxyServerList(initialUrls: string[]){
+    for (let i=0; i < ACTIVE_PROXIES.length; i += 1){
+        ACTIVE_PROXIES.pop();
+    }
     initialUrls.forEach(url => {
         addProxyServer(url);
     })

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,9 +1,10 @@
 import { Express } from "express";
-import { addServer } from "./serverManager";
+import { addServer, initializeServerList } from "./serverManager";
 import { forwardRequest } from "./forwarder";
 import { isAxiosError } from "axios";
 import { handshake } from "./handshake";
-import { addProxyServer } from "./proxyManager";
+import { addProxyServer, initializeProxyServerList } from "./proxyManager";
+import { initialProxyList, initialServerList } from "./initialValues";
 
 export function initializeRoutes(app: Express){
     app.get('/hello', function(req, res){
@@ -34,6 +35,13 @@ export function initializeRoutes(app: Express){
              return;
         }
         addProxyServer(serverUrl);
+    });
+
+    app.get('/resetToDefaults', function(req,res){
+        // For debug purposes
+        initializeProxyServerList(initialProxyList);
+        initializeServerList(initialServerList);
+        res.status(200).send('Reset to defaults');
     });
 
     app.get('/err', function(req, res){

--- a/src/serverManager.ts
+++ b/src/serverManager.ts
@@ -1,6 +1,9 @@
 const ACTIVE_SERVERS = [];
 
 export function initializeServerList(initialUrls: string[]){
+    for (let i=0; i < ACTIVE_SERVERS.length; i += 1){
+        ACTIVE_SERVERS.pop();
+    }
     initialUrls.forEach(url => {
         addServer(url);
     })


### PR DESCRIPTION
- In case of 500 level errors from all, they will be checked to see if they can return a successful response for a ping before they are completely dropped. 
- In case of 500 level errors from some, the offenders will resync
- New route for debugging to reset to default proxyList and app server list